### PR TITLE
Pin Python 3.13 and drop EOL buster variant

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -65,7 +65,7 @@ jobs:
             ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-bullseye
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            IMAGE_PREFIX=python:3-bullseye
+            IMAGE_PREFIX=python:3.13-bullseye
             CFN_LINT_VERSION=${{ steps.get_version.outputs.VERSION }}
 
       - name: Test Bullseye
@@ -82,28 +82,11 @@ jobs:
             ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-slim
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            IMAGE_PREFIX=python:3-slim
+            IMAGE_PREFIX=python:3.13-slim
             CFN_LINT_VERSION=${{ steps.get_version.outputs.VERSION }}
 
       - name: Test Slim
         run: docker run --rm -v "$(pwd):/opt" giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-slim /opt/tests/template.yaml
-
-      - name: Build Buster
-        uses: docker/build-push-action@v2.7.0
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-buster
-            ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-buster
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            IMAGE_PREFIX=python:3-buster
-            CFN_LINT_VERSION=${{ steps.get_version.outputs.VERSION }}
-
-      - name: Test Buster
-        run: docker run --rm -v "$(pwd):/opt" giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-buster /opt/tests/template.yaml
 
       # PUSH SECTION
 
@@ -132,7 +115,7 @@ jobs:
             ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-bullseye
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            IMAGE_PREFIX=python:3-bullseye
+            IMAGE_PREFIX=python:3.13-bullseye
             CFN_LINT_VERSION=${{ steps.get_version.outputs.VERSION }}
 
       - name: Push Slim
@@ -146,19 +129,5 @@ jobs:
             ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-slim
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            IMAGE_PREFIX=python:3-slim
-            CFN_LINT_VERSION=${{ steps.get_version.outputs.VERSION }}
-
-      - name: Push Buster
-        uses: docker/build-push-action@v2.7.0
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-buster
-            ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-buster
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            IMAGE_PREFIX=python:3-buster
+            IMAGE_PREFIX=python:3.13-slim
             CFN_LINT_VERSION=${{ steps.get_version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_PREFIX='python:3-alpine'
+ARG IMAGE_PREFIX='python:3.13-alpine'
 FROM ${IMAGE_PREFIX}
 
 ARG CFN_LINT_VERSION=''

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ Tags are published continuously to:
 - Docker Hub: <https://hub.docker.com/r/giammbo/cfn-lint/tags>
 - GHCR: <https://github.com/giammbo/cfn-lint/pkgs/container/cfn-lint>
 
-For each upstream cfn-lint release `X.Y.Z` four variants are produced:
+For each upstream cfn-lint release `X.Y.Z` three variants are produced:
 
 - `X.Y.Z` (default, alpine-based) — also tagged `latest` for the most recent release
 - `X.Y.Z-bullseye`
 - `X.Y.Z-slim`
-- `X.Y.Z-buster`
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Pin all Dockerfile variants to `python:3.13-*` (was `python:3-*` which now resolves to Python 3.14, outside the cfn-lint supported range `>=3.10,<3.14`)
- Drop `-buster` variant: Debian buster is EOL and `python:3.13-buster` is not published on Docker Hub
- Update README to reflect 3 variants instead of 4

This unblocks the auto-build workflow, which currently fails on the pip install step for any cfn-lint >=1.49.

## Test plan
- [x] YAML syntactically valid
- [ ] After merge: re-tag `1.50.0` to retrigger the Upload Image workflow and verify all 3 variants build and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)