### PR TITLE
Load images into local daemon so in-job tests can run them

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -43,7 +43,8 @@ jobs:
         with:
           context: .
           push: false
-          platforms: linux/amd64,linux/arm64
+          load: true
+          platforms: linux/amd64
           tags: |
             giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}
             giammbo/cfn-lint:latest
@@ -59,7 +60,8 @@ jobs:
         with:
           context: .
           push: false
-          platforms: linux/amd64,linux/arm64
+          load: true
+          platforms: linux/amd64
           tags: |
             giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-bullseye
             ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-bullseye
@@ -76,7 +78,8 @@ jobs:
         with:
           context: .
           push: false
-          platforms: linux/amd64,linux/arm64
+          load: true
+          platforms: linux/amd64
           tags: |
             giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-slim
             ghcr.io/giammbo/cfn-lint:${{ steps.get_version.outputs.VERSION }}-slim


### PR DESCRIPTION
## Summary
The Build steps used \`push: false\` + multi-arch platforms without \`load: true\`. buildx kept the result only in its build cache, so \`docker run\` in the Test steps failed with \"manifest unknown\". Add \`load: true\` and restrict the Build steps to \`linux/amd64\` (load requires a single host-architecture platform). Push steps remain multi-arch.

## Test plan
- [ ] After merge: re-tag \`1.50.0\` and verify the Upload Image workflow completes successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)